### PR TITLE
Fixed: QR code service - the URL length limit not needed

### DIFF
--- a/sql/description.sql
+++ b/sql/description.sql
@@ -1277,11 +1277,6 @@ create procedure fct_make_curie (in url varchar, in lines any)
   declare curie, chost, dhost varchar;
   declare len integer;
 
-  len := cast (registry_get('c_uri_min_url_len') as integer);
-  if (len = 0) len := 255;
-  if (__proc_exists ('WS.CURI.curi_make_curi') is null OR length(url) < len)
-    return url;
-
   curie := WS.CURI.curi_make_curi (url);
   dhost := registry_get ('URIQADefaultHost');
   chost := http_request_header(lines, 'Host', null, dhost);


### PR DESCRIPTION
Always make short URIs (cURI), if limit is needed this must be part of c_uri VAD package.