### PR TITLE
Added support for showing custom datatypes

### DIFF
--- a/sql/description.sql
+++ b/sql/description.sql
@@ -1130,7 +1130,8 @@ again:
        else
          http_value (vlbl);
        http ('</span>');
-       --lang := '';
+       if ((lang is NULL or lang = '') and rdfs_type <> 'http://www.w3.org/2001/XMLSchema#string')
+         lang := b3s_xsd_link (rdfs_type);
      }
    else if (__tag (_object) = 211)
      {


### PR DESCRIPTION
Custom datatype is not shown when the value is treated as a string. When there is no language and it is not `xsd:string`, it should be displayed.

Reported-by: IS4Code